### PR TITLE
fix: grab node schema defaultOptions from right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [5.3.3] - 2019-02-26
+- fix: Grab node schema defaultOptions from right place
+
 ## [5.3.2] - 2019-01-06
 - feature: Add moveSelectionToStart and moveSelectionToEnd utility functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubpub/editor",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "PubPub Collaborative Editor",
   "main": "dist/index.js",
   "author": "PubPub Team <pubpub@media.mit.edu>",

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -61,7 +61,7 @@ export const renderStatic = (schema = buildSchema(), nodeArray, editorProps) => 
 		nodeWithIndex.currIndex = index;
 		const nodeOptions = editorProps.nodeOptions || {};
 		const customOptions = nodeOptions[node.type] || {};
-		const mergedOptions = { ...schema.nodes[node.type].defaultOptions, ...customOptions };
+		const mergedOptions = { ...schema.nodes[node.type].spec.defaultOptions, ...customOptions };
 		const NodeComponent = schema.nodes[node.type].spec.toStatic(
 			nodeWithIndex,
 			mergedOptions,


### PR DESCRIPTION
This should fix an issue that has been breaking Pandoc export of pubs with discussion embeds. We'll need to update this package and do a release to actually fix this in PubPub.

The issue was that we were trying to pluck `defaultOptions` from a ProseMirror schema node, but that's not it lives; instead we need to get it off the node's `spec` instead. Don't worry, I find it confusing too!