### PR TITLE
fix: Preserve newlines when pasting code blocks

### DIFF
--- a/src/schemas/base.js
+++ b/src/schemas/base.js
@@ -212,7 +212,7 @@ export const baseNodes = {
 		content: 'text*',
 		group: 'block',
 		code: true,
-		parseDOM: [{ tag: 'pre', preserveWhitespace: true }],
+		parseDOM: [{ tag: 'pre', preserveWhitespace: 'full' }],
 		toDOM: () => {
 			return ['pre', ['code', 0]];
 		},


### PR DESCRIPTION
This fixes the problem identified in #22 where pasting a copied code block collapses newlines within the code block.

_Test plan:_
- Run `npm start` and navigate to the test editor
- Start a code block with three backticks and type some code with some newlines. Highlight and copy it.
- Refresh the editor and paste the code in. Verify that it still has newlines.