### PR TITLE
Change footnote and cite positioning, add z-index

### DIFF
--- a/src/components/Citation/citation.scss
+++ b/src/components/Citation/citation.scss
@@ -8,7 +8,8 @@
 	.render-wrapper {
 		display: none;
 		position: absolute;
-		bottom: 1em;
+		z-index: 1;
+		top: 1.5em;
 		left: 0;
 		width: 400px;
 		padding: 15px;

--- a/src/components/Footnote/footnote.scss
+++ b/src/components/Footnote/footnote.scss
@@ -8,7 +8,8 @@
 	.render-wrapper {
 		display: none;
 		position: absolute;
-		bottom: 1em;
+		z-index: 1;
+		top: 1.5em;
 		left: 0;
 		width: 400px;
 		padding: 15px;


### PR DESCRIPTION
This defaults footnotes and citations to opening down, rather than up, as a temporary solution to prevent them from opening off the top of the editor body, which is often occluded by a backgrounded block element that causes the cite/footer not to show. They can still open below the editor, but in most cases there's enough padding or other content below the footer to not have this issue. The long-term solution is still some sort of direction-sensing component.

<img width="926" alt="Screen Shot 2019-08-14 at 5 20 01 PM" src="https://user-images.githubusercontent.com/639110/63057229-c54d9780-beb7-11e9-9610-12e32c9c6d2a.png">

The z-index appears to be needed to prevent overlap with other elements within the editor, but I'm not an expert in it.

<img width="719" alt="Screen Shot 2019-08-14 at 5 20 47 PM" src="https://user-images.githubusercontent.com/639110/63057287-e3b39300-beb7-11e9-8343-07ebf9d6489c.png">